### PR TITLE
feat (ngRoute): add route params support in controller definition

### DIFF
--- a/angular-route.js
+++ b/angular-route.js
@@ -501,7 +501,7 @@ function $RouteProvider(){
           then(function() {
             if (next) {
               var locals = extend({}, next.resolve),
-                  template, templateUrl;
+                  template, templateUrl, controller;
 
               forEach(locals, function(value, key) {
                 locals[key] = isString(value) ? $injector.get(value) : $injector.invoke(value);
@@ -521,6 +521,15 @@ function $RouteProvider(){
                   template = $http.get(templateUrl, {cache: $templateCache}).
                       then(function(response) { return response.data; });
                 }
+              }
+              if (isDefined(controller = next.controller)) {
+                if (isFunction(controller)) {
+                  controller = controller(next.params);
+                }
+              }
+              if (isDefined(controller)) {
+                next.controller = controller;
+                locals['$controller'] = controller;
               }
               if (isDefined(template)) {
                 locals['$template'] = template;


### PR DESCRIPTION
provide route params support in controller definition, using route params for set the application controller and another behaviours via ngRoute. 

default behaviour:

```
$routeProvider
    //  Default call
    .when('/main', {
        templateUrl: 'views/angular-smart-table.html',
        controller: 'MainCtrl'
      });
```

behaviour using route params support:

```
$routeProvider
    //  Default call
    .when('/:section', {
        templateUrl: function(req) {
            return 'views/' + req.section + '.html';
        },
        controller: function(req) {
            return req.section+ 'Ctrl';
        }
    });
```
