### PR TITLE
Add Composer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Please file issues and pull requests against that repo.
 
 ## Install
 
-Install with `bower`:
+Install with [`bower`](http://bower.io) or [`composer`](http://getcomposer.org):
 
 ```shell
 bower install angular-route
+composer require angular/bower-angular-route:*
 ```
 
 Add a `<script>` to your `index.html`:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "angular/bower-angular-route",
+  "description": "Routing module for AngularJS",
+  "type": "component",
+  "homepage": "http://angularjs.org",
+  "license": "MIT",
+  "require": {
+    "components/angular.js": "1.2.0"
+  },
+  "extra": {
+    "component": {
+      "name": "angular-route",
+      "scripts": [
+        "angular-route.js"
+      ],
+      "files": [
+        "angular-route.min.js",
+        "angular-route.min.js.map"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This allows Angular Route to be consumed by [Composer](http://getcomposer.org)-based projects.

RE: https://github.com/components/angular.js/pull/1#issuecomment-28305579
