### PR TITLE
remove/info-method-on-module

### DIFF
--- a/angular-route.js
+++ b/angular-route.js
@@ -59,7 +59,6 @@ var noop;
 /* global -ngRouteModule */
 var ngRouteModule = angular.
   module('ngRoute', []).
-  info({ angularVersion: '1.6.3-build.5306+sha.6ccbfa6' }).
   provider('$route', $RouteProvider).
   // Ensure `$route` will be instantiated in time to capture the initial `$locationChangeSuccess`
   // event (unless explicitly disabled). This is necessary in case `ngView` is included in an


### PR DESCRIPTION
remove `info({ angularVersion: '1.6.3-build.5305+sha.cc793a1' }) ` (line 62)
actually that info method doesn't seem to exist and breaks current angular route implementation. seems like this happened 4 days ago. also should be removed in the minified version OR the info method should be created, so that the code doesn't fail.

I tried using it with angular versions 1.5.8 up to 1.6.2

Happy to help either way. Thx